### PR TITLE
[MLSE-1722]Enabling get_annotations to use export v2

### DIFF
--- a/labelsnow/constants.py
+++ b/labelsnow/constants.py
@@ -1,17 +1,5 @@
 LABELBOX_DEFAULT_TYPE_DICTIONARY = {
-    'ID': 'string',
-    'DataRow ID': 'string',
-    'Labeled Data': 'string',
-    'Created By': 'string',
-    'Project Name': 'string',
-    'Seconds to Label': 'float64',
-    'External ID': 'string',
-    'Agreement': 'int64',
-    'Benchmark Agreement': 'int64',
-    'Benchmark ID': 'string',
-    'Dataset Name': 'string',
-    'Reviews': 'object',
-    'View Label': 'string',
-    'Has Open Issues': 'int64',
-    'Skipped': 'bool'
+    'data_row': 'object',
+    'media_attributes': 'object',
+    'projects': 'object',
 }

--- a/labelsnow/flatten_bronze_table.py
+++ b/labelsnow/flatten_bronze_table.py
@@ -6,7 +6,7 @@ def flatten_bronze_table(df):
 
     df = df.reset_index()
 
-    s = (df.applymap(type) == dict).all()
+    s = (df.map(type) == dict).all()
     dict_columns = s[s].index.tolist()
 
     while len(dict_columns) > 0:
@@ -20,7 +20,7 @@ def flatten_bronze_table(df):
             new_columns.extend(horiz_exploded.columns)  # inplace
 
         # check if there are still dict fields to flatten
-        s = (df[new_columns].applymap(type) == dict).all()
+        s = (df[new_columns].map(type) == dict).all()
         dict_columns = s[s].index.tolist()
 
     logging.info("flatten_bronze_table: Returning flattened table.")

--- a/labelsnow/get_annotations.py
+++ b/labelsnow/get_annotations.py
@@ -1,5 +1,3 @@
-import json
-import urllib
 import pandas as pd
 import logging
 from labelsnow.constants import LABELBOX_DEFAULT_TYPE_DICTIONARY
@@ -8,15 +6,13 @@ from labelsnow.constants import LABELBOX_DEFAULT_TYPE_DICTIONARY
 def get_annotations(labelbox_client, project_id):
     """Request annotations for a specific project_id and produce a Snowflake-ready Pandas Dataframe"""
     project = labelbox_client.get_project(project_id)
-    with urllib.request.urlopen(project.export_labels()) as url:
-        api_response_string = url.read().decode()  # this is a string of JSONs
 
-    data = json.loads(api_response_string)
+    task = project.export_v2()
+    task.wait_till_done()
+    if task.errors:
+        logging.warn("Error while exporting: ", task.errors)
+    data = task.result
     df = pd.DataFrame.from_dict(data).astype(LABELBOX_DEFAULT_TYPE_DICTIONARY)
-
-    #For some reason dtype dict does not convert timestamp reliably, so I must include these manual conversions
-    df["Created At"] = pd.to_datetime(df["Created At"])
-    df["Updated At"] = pd.to_datetime(df["Updated At"])
 
     logging.info("Returning annotations DataFrame from Labelbox")
     return df

--- a/labelsnow/get_videoframe_annotations.py
+++ b/labelsnow/get_videoframe_annotations.py
@@ -36,8 +36,9 @@ def get_videoframe_annotations(bronze_video_labels, project_id):
                                 "DataRow ID": row["data_row"]["id"],
                                 "Label": frames[str(frame)]["objects"][feature_id]
                             })
-        massive_string_of_responses = json.dumps(data)
-        master_array_of_json_arrays.append(massive_string_of_responses)
+        if data:
+            massive_string_of_responses = json.dumps(data)
+            master_array_of_json_arrays.append(massive_string_of_responses)
 
     array_of_bronze_dataframes = []
     for frameset in master_array_of_json_arrays:

--- a/labelsnow/silver_table.py
+++ b/labelsnow/silver_table.py
@@ -8,7 +8,7 @@ def silver_table(df):
     flattened_bronze = flatten_bronze_table(df)
 
     # search for columns to explode/flatten
-    s = (flattened_bronze.applymap(type) == list).all()
+    s = (flattened_bronze.map(type) == list).all()
     list_columns = s[s].index.tolist(
     )  #generally yields ['Label_objects', 'Label_classifications', 'Label_relationships']
 
@@ -81,7 +81,7 @@ def silver_table(df):
         except Exception as e:
             print(e)
 
-        my_dictionary["DataRow ID"] = row["DataRow ID"]  # close it out
+        my_dictionary["data_row_id"] = row["data_row_id"]  # close it out
         if video:
             my_dictionary["Label_frameNumber"] = row[
                 "Label_frameNumber"]  # need to store the unique framenumber identifier for video
@@ -94,12 +94,12 @@ def silver_table(df):
         joined_df = pd.merge(parsed_classifications,
                              flattened_bronze,
                              how='inner',
-                             on=["DataRow ID", "Label_frameNumber"])
+                             on=["data_row_id", "Label_frameNumber"])
     else:
         joined_df = pd.merge(parsed_classifications,
                              flattened_bronze,
                              how='inner',
-                             on="DataRow ID")
+                             on="data_row_id")
         # joined_df = parsed_classifications.join(flattened_bronze, ["DataRow ID"],
         #                                         "inner")
 

--- a/setup.py
+++ b/setup.py
@@ -13,6 +13,6 @@ setuptools.setup(
     long_description_content_type="text/markdown",
     url="https://labelbox.com",
     packages=setuptools.find_packages(),
-    install_requires=["labelbox", "pandas", "snowflake-connector-python"],
+    install_requires=["labelbox", "pandas>=2.1.0", "snowflake-connector-python"],
     keywords=["labelbox", "labelsnow"],
 )


### PR DESCRIPTION
A breaking change that includes enabling exports v2 to be used for annotation export. The breaking change is in the DataFrame columns being exported. The new column mapping for export v2 does not match export v1 and the client code using this library will need to be adjusted. 

Outlined below is the breaking change:
- Previously exported annotations included the columns below:
```
{
    'ID': 'string',
    'DataRow ID': 'string',
    'Labeled Data': 'string',
    'Created By': 'string',
    'Project Name': 'string',
    'Seconds to Label': 'float64',
    'External ID': 'string',
    'Agreement': 'int64',
    'Benchmark Agreement': 'int64',
    'Benchmark ID': 'string',
    'Dataset Name': 'string',
    'Reviews': 'object',
    'View Label': 'string',
    'Has Open Issues': 'int64',
    'Skipped': 'bool'
}
```

- The new column keys are:
```
{
    'data_row': 'object',
    'media_attributes': 'object',
    'projects': 'object',
}
```